### PR TITLE
chore: rename backend to PrototypeAI

### DIFF
--- a/prototype_ai/README.md
+++ b/prototype_ai/README.md
@@ -1,0 +1,39 @@
+# PrototypeAI Backend
+
+PrototypeAI is a minimal Python backend demonstrating an LLM‑driven system that can
+generate files and run commands. It is *LLM agnostic* and can speak to OpenAI, Azure
+OpenAI, or Google Gemini through a shared interface.
+
+## Architecture
+
+* **LLM clients** – provider‑specific wrappers implement a common `BaseClient` interface.
+* **Switchable stream** – supports continuation when the model reaches a token limit.
+* **FastAPI route** – `POST /api/chat` streams text from the selected model and handles
+  continuation prompts.
+
+## Generating files & running commands
+
+Model responses are expected to contain `<prototypeArtifact>` blocks. Each block may hold
+multiple `<prototypeAction>` elements:
+
+* `<prototypeAction type="file" filePath="path/to/file">` – write or update files.
+* `<prototypeAction type="shell">` – run shell commands to install dependencies or start
+  processes.
+
+Files are written relative to a workspace directory (e.g. the project root) so the
+generated application can be executed immediately after the model finishes.
+
+## Running the server
+
+1. Set `LLM_PROVIDER` to `openai`, `azure`, or `gemini` and export the matching API
+   credentials in your environment.
+2. Change into this directory and start the FastAPI app:
+
+   ```bash
+   cd prototype_ai
+   uvicorn server.chat:app --reload
+   ```
+
+3. Send chat requests to `POST /api/chat` with a list of `{role, content}` messages.
+
+The route streams the model output and automatically requests continuation when needed.

--- a/prototype_ai/__init__.py
+++ b/prototype_ai/__init__.py
@@ -1,0 +1,1 @@
+"PrototypeAI package."

--- a/prototype_ai/llm/__init__.py
+++ b/prototype_ai/llm/__init__.py
@@ -1,0 +1,13 @@
+from .base import LLMClient
+from .factory import create_client
+from .openai_client import OpenAIClient
+from .azure_openai_client import AzureOpenAIClient
+from .gemini_client import GeminiClient
+
+__all__ = [
+  "LLMClient",
+  "create_client",
+  "OpenAIClient",
+  "AzureOpenAIClient",
+  "GeminiClient",
+]

--- a/prototype_ai/llm/azure_openai_client.py
+++ b/prototype_ai/llm/azure_openai_client.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Dict, List
+
+try:
+  from openai import AzureOpenAI
+except Exception:  # pragma: no cover - optional dependency
+  AzureOpenAI = None
+
+from .base import LLMClient
+
+
+class AzureOpenAIClient(LLMClient):
+  def __init__(self, api_key: str, endpoint: str, deployment: str):
+    if AzureOpenAI is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("openai package with AzureOpenAI is required")
+    self.client = AzureOpenAI(
+      api_key=api_key,
+      api_version="2024-02-15-preview",
+      azure_endpoint=endpoint,
+    )
+    self.deployment = deployment
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+  ) -> AsyncGenerator[str, None]:
+    payload = [{"role": "system", "content": system_prompt}, *messages]
+    response = await self.client.chat.completions.create(
+      model=self.deployment,
+      messages=payload,
+      max_tokens=max_tokens,
+      stream=True,
+    )
+    async for chunk in response:
+      token = chunk.choices[0].delta.get("content")
+      if token:
+        yield token

--- a/prototype_ai/llm/base.py
+++ b/prototype_ai/llm/base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncGenerator, Dict, List
+
+
+class LLMClient(ABC):
+  @abstractmethod
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+  ) -> AsyncGenerator[str, None]:
+    """Yield tokens for the given conversation."""
+    raise NotImplementedError

--- a/prototype_ai/llm/factory.py
+++ b/prototype_ai/llm/factory.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .azure_openai_client import AzureOpenAIClient
+from .gemini_client import GeminiClient
+from .openai_client import OpenAIClient
+
+
+def create_client(provider: str, **kwargs):
+  provider = provider.lower()
+  if provider == "openai":
+    return OpenAIClient(**kwargs)
+  if provider == "azure":
+    return AzureOpenAIClient(**kwargs)
+  if provider == "gemini":
+    return GeminiClient(**kwargs)
+  raise ValueError(f"Unknown provider: {provider}")

--- a/prototype_ai/llm/gemini_client.py
+++ b/prototype_ai/llm/gemini_client.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Dict, List
+
+import asyncio
+
+try:
+  import google.generativeai as genai
+except Exception:  # pragma: no cover - optional dependency
+  genai = None
+
+from .base import LLMClient
+
+
+class GeminiClient(LLMClient):
+  def __init__(self, api_key: str, model: str = "gemini-pro"):
+    if genai is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("google-generativeai package is required")
+    genai.configure(api_key=api_key)
+    self.model = genai.GenerativeModel(model)
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+  ) -> AsyncGenerator[str, None]:
+    full_prompt = "\n".join([system_prompt] + [m["content"] for m in messages])
+    stream = await asyncio.to_thread(
+      self.model.generate_content,
+      full_prompt,
+      stream=True,
+      generation_config={"max_output_tokens": max_tokens},
+    )
+    for chunk in stream:
+      if chunk.text:
+        yield chunk.text

--- a/prototype_ai/llm/openai_client.py
+++ b/prototype_ai/llm/openai_client.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Dict, List
+
+import asyncio
+
+try:
+  import openai
+except Exception:  # pragma: no cover - optional dependency
+  openai = None
+
+from .base import LLMClient
+
+
+class OpenAIClient(LLMClient):
+  def __init__(self, api_key: str, model: str):
+    if openai is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("openai package is required")
+    openai.api_key = api_key
+    self.model = model
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+  ) -> AsyncGenerator[str, None]:
+    payload = [{"role": "system", "content": system_prompt}, *messages]
+    response = await openai.ChatCompletion.acreate(
+      model=self.model,
+      messages=payload,
+      max_tokens=max_tokens,
+      stream=True,
+    )
+    async for chunk in response:
+      token = chunk["choices"][0]["delta"].get("content")
+      if token:
+        yield token

--- a/prototype_ai/server/__init__.py
+++ b/prototype_ai/server/__init__.py
@@ -1,0 +1,4 @@
+from .chat import app
+from .switchable_stream import SwitchableStream
+
+__all__ = ["app", "SwitchableStream"]

--- a/prototype_ai/server/chat.py
+++ b/prototype_ai/server/chat.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from ..llm import create_client
+from .switchable_stream import SwitchableStream
+
+SYSTEM_PROMPT = "You are PrototypeAI, an expert AI assistant."
+CONTINUE_PROMPT = (
+  "Continue your prior response. IMPORTANT: Immediately begin from where you left off without any interruptions.\n"
+  "Do not repeat any content, including artifact and action tags."
+)
+MAX_TOKENS = 4096
+MAX_RESPONSE_SEGMENTS = 8
+
+app = FastAPI()
+
+
+def _client():
+  provider = os.getenv("LLM_PROVIDER", "openai")
+  if provider == "openai":
+    return create_client(
+      provider,
+      api_key=os.environ["OPENAI_API_KEY"],
+      model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+    )
+  if provider == "azure":
+    return create_client(
+      provider,
+      api_key=os.environ["AZURE_OPENAI_API_KEY"],
+      endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+      deployment=os.environ["AZURE_OPENAI_DEPLOYMENT"],
+    )
+  if provider == "gemini":
+    return create_client(
+      provider,
+      api_key=os.environ["GEMINI_API_KEY"],
+      model=os.getenv("GEMINI_MODEL", "gemini-pro"),
+    )
+  raise ValueError(f"Unknown provider: {provider}")
+
+
+@app.post("/api/chat")
+async def chat(request: Request):
+  body = await request.json()
+  messages: List[Dict[str, str]] = body["messages"]
+  client = _client()
+  stream = SwitchableStream()
+
+  async def run():
+    nonlocal messages
+    for _ in range(MAX_RESPONSE_SEGMENTS):
+      llm_stream = client.stream_text(messages, SYSTEM_PROMPT, MAX_TOKENS)
+      await stream.switch(llm_stream)
+      collected: List[str] = []
+      async for token in stream:
+        collected.append(token)
+        yield token
+      if len(collected) < MAX_TOKENS:
+        break
+      messages.append({"role": "assistant", "content": "".join(collected)})
+      messages.append({"role": "user", "content": CONTINUE_PROMPT})
+
+  return StreamingResponse(run(), media_type="text/plain")

--- a/prototype_ai/server/switchable_stream.py
+++ b/prototype_ai/server/switchable_stream.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator, Optional
+
+
+class SwitchableStream:
+  def __init__(self):
+    self._current: Optional[asyncio.Task] = None
+    self._queue: asyncio.Queue[Optional[str]] = asyncio.Queue()
+    self.switches = 0
+
+  async def _pump(self, stream: AsyncGenerator[str, None]):
+    try:
+      async for token in stream:
+        await self._queue.put(token)
+    finally:
+      await self._queue.put(None)
+
+  async def switch(self, stream: AsyncGenerator[str, None]):
+    if self._current:
+      self._current.cancel()
+    self._current = asyncio.create_task(self._pump(stream))
+    self.switches += 1
+
+  async def __aiter__(self):
+    while True:
+      token = await self._queue.get()
+      if token is None:
+        break
+      yield token


### PR DESCRIPTION
## Summary
- rename sample Python backend to PrototypeAI
- expand documentation with architecture, file generation, and server setup instructions
- update system prompt to reference PrototypeAI

## Testing
- `pnpm test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1985fe76083308f9c2b981745f973