### PR TITLE
feat: extend PrototypeAI with Python client executor

### DIFF
--- a/prototype_ai/README.md
+++ b/prototype_ai/README.md
@@ -1,0 +1,42 @@
+# PrototypeAI Backend
+
+PrototypeAI is a minimal Python backend demonstrating an LLM‑driven system that can
+generate files and run commands. It is *LLM agnostic* and can speak to OpenAI, Azure
+OpenAI, or Google Gemini through a shared interface.
+
+## Architecture
+
+* **LLM clients** – provider‑specific wrappers implement a common `LLMClient` interface.
+* **System prompts** – `get_system_prompt()` and `CONTINUE_PROMPT` mirror the instructions
+  used by the original Bolt backend.
+* **Switchable stream** – replaces the active LLM stream when the model hits the token
+  limit.
+* **FastAPI route** – `POST /api/chat` streams text and requests continuation until
+  `MAX_RESPONSE_SEGMENTS` is reached.
+
+## Generating files & running commands
+
+Model responses are expected to contain `<prototypeArtifact>` blocks. Each block may hold
+multiple `<prototypeAction>` elements:
+
+* `<prototypeAction type="file" filePath="path/to/file">` – write or update files.
+* `<prototypeAction type="shell">` – run shell commands to install dependencies or start
+  processes.
+
+Files are written relative to a workspace directory (e.g. the project root) so the
+generated application can be executed immediately after the model finishes.
+
+## Running the server
+
+1. Set `LLM_PROVIDER` to `openai`, `azure`, or `gemini` and export the matching API
+   credentials in your environment.
+2. Change into this directory and start the FastAPI app:
+
+   ```bash
+   cd prototype_ai
+   uvicorn server.chat:app --reload
+   ```
+
+3. Send chat requests to `POST /api/chat` with a list of `{role, content}` messages.
+
+The route streams the model output and automatically requests continuation when needed.

--- a/prototype_ai/__init__.py
+++ b/prototype_ai/__init__.py
@@ -1,0 +1,1 @@
+"PrototypeAI package."

--- a/prototype_ai/llm/__init__.py
+++ b/prototype_ai/llm/__init__.py
@@ -1,0 +1,22 @@
+from .base import LLMClient
+from .constants import MAX_TOKENS, MAX_RESPONSE_SEGMENTS
+from .factory import create_client, client_from_env
+from .openai_client import OpenAIClient
+from .azure_openai_client import AzureOpenAIClient
+from .gemini_client import GeminiClient
+from .prompts import CONTINUE_PROMPT, get_system_prompt
+from .stream_text import stream_text
+
+__all__ = [
+  "LLMClient",
+  "create_client",
+  "client_from_env",
+  "OpenAIClient",
+  "AzureOpenAIClient",
+  "GeminiClient",
+  "get_system_prompt",
+  "CONTINUE_PROMPT",
+  "stream_text",
+  "MAX_TOKENS",
+  "MAX_RESPONSE_SEGMENTS",
+]

--- a/prototype_ai/llm/azure_openai_client.py
+++ b/prototype_ai/llm/azure_openai_client.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+try:
+  from openai import AzureOpenAI
+except Exception:  # pragma: no cover - optional dependency
+  AzureOpenAI = None
+
+from .base import LLMClient
+
+
+class AzureOpenAIClient(LLMClient):
+  def __init__(self, api_key: str, endpoint: str, deployment: str):
+    if AzureOpenAI is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("openai package with AzureOpenAI is required")
+    self.client = AzureOpenAI(
+      api_key=api_key,
+      api_version="2024-02-15-preview",
+      azure_endpoint=endpoint,
+    )
+    self.deployment = deployment
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+    on_finish: Optional[Callable[[str, str], Awaitable[None]]] = None,
+  ) -> AsyncGenerator[str, None]:
+    payload = [{"role": "system", "content": system_prompt}, *messages]
+    response = await self.client.chat.completions.create(
+      model=self.deployment,
+      messages=payload,
+      max_tokens=max_tokens,
+      stream=True,
+    )
+    collected: List[str] = []
+    finish_reason = "stop"
+    async for chunk in response:
+      choice = chunk.choices[0]
+      token = choice.delta.get("content")
+      if token:
+        collected.append(token)
+        yield token
+      if getattr(choice, "finish_reason", None):
+        finish_reason = choice.finish_reason
+    if on_finish:
+      await on_finish("".join(collected), finish_reason)

--- a/prototype_ai/llm/base.py
+++ b/prototype_ai/llm/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+
+class LLMClient(ABC):
+  @abstractmethod
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+    on_finish: Optional[Callable[[str, str], Awaitable[None]]] = None,
+  ) -> AsyncGenerator[str, None]:
+    """Yield tokens for the given conversation."""
+    raise NotImplementedError

--- a/prototype_ai/llm/factory.py
+++ b/prototype_ai/llm/factory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+from .azure_openai_client import AzureOpenAIClient
+from .gemini_client import GeminiClient
+from .openai_client import OpenAIClient
+
+
+def create_client(provider: str, **kwargs):
+  provider = provider.lower()
+  if provider == "openai":
+    return OpenAIClient(**kwargs)
+  if provider == "azure":
+    return AzureOpenAIClient(**kwargs)
+  if provider == "gemini":
+    return GeminiClient(**kwargs)
+  raise ValueError(f"Unknown provider: {provider}")
+
+
+def client_from_env():
+  provider = os.getenv("LLM_PROVIDER", "openai").lower()
+  if provider == "openai":
+    return create_client(
+      provider,
+      api_key=os.environ["OPENAI_API_KEY"],
+      model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+    )
+  if provider == "azure":
+    return create_client(
+      provider,
+      api_key=os.environ["AZURE_OPENAI_API_KEY"],
+      endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+      deployment=os.environ["AZURE_OPENAI_DEPLOYMENT"],
+    )
+  if provider == "gemini":
+    return create_client(
+      provider,
+      api_key=os.environ["GEMINI_API_KEY"],
+      model=os.getenv("GEMINI_MODEL", "gemini-pro"),
+    )
+  raise ValueError(f"Unknown provider: {provider}")

--- a/prototype_ai/llm/gemini_client.py
+++ b/prototype_ai/llm/gemini_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+import asyncio
+
+try:
+  import google.generativeai as genai
+except Exception:  # pragma: no cover - optional dependency
+  genai = None
+
+from .base import LLMClient
+
+
+class GeminiClient(LLMClient):
+  def __init__(self, api_key: str, model: str = "gemini-pro"):
+    if genai is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("google-generativeai package is required")
+    genai.configure(api_key=api_key)
+    self.model = genai.GenerativeModel(model)
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+    on_finish: Optional[Callable[[str, str], Awaitable[None]]] = None,
+  ) -> AsyncGenerator[str, None]:
+    full_prompt = "\n".join([system_prompt] + [m["content"] for m in messages])
+    stream = await asyncio.to_thread(
+      self.model.generate_content,
+      full_prompt,
+      stream=True,
+      generation_config={"max_output_tokens": max_tokens},
+    )
+    text_parts: List[str] = []
+    for chunk in stream:
+      if chunk.text:
+        text_parts.append(chunk.text)
+        yield chunk.text
+    if on_finish:
+      await on_finish("".join(text_parts), "stop")

--- a/prototype_ai/llm/openai_client.py
+++ b/prototype_ai/llm/openai_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+import asyncio
+
+try:
+  import openai
+except Exception:  # pragma: no cover - optional dependency
+  openai = None
+
+from .base import LLMClient
+
+
+class OpenAIClient(LLMClient):
+  def __init__(self, api_key: str, model: str):
+    if openai is None:  # pragma: no cover - runtime guard
+      raise RuntimeError("openai package is required")
+    openai.api_key = api_key
+    self.model = model
+
+  async def stream_text(
+    self,
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    max_tokens: int,
+    on_finish: Optional[Callable[[str, str], Awaitable[None]]] = None,
+  ) -> AsyncGenerator[str, None]:
+    payload = [{"role": "system", "content": system_prompt}, *messages]
+    response = await openai.ChatCompletion.acreate(
+      model=self.model,
+      messages=payload,
+      max_tokens=max_tokens,
+      stream=True,
+    )
+    collected: List[str] = []
+    finish_reason = "stop"
+    async for chunk in response:
+      choice = chunk["choices"][0]
+      token = choice["delta"].get("content")
+      if token:
+        collected.append(token)
+        yield token
+      if choice.get("finish_reason"):
+        finish_reason = choice["finish_reason"]
+    if on_finish:
+      await on_finish("".join(collected), finish_reason)

--- a/prototype_ai/llm/prompts.py
+++ b/prototype_ai/llm/prompts.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+ALLOWED_HTML_ELEMENTS = [
+  'a', 'b', 'blockquote', 'br', 'code', 'dd', 'del', 'details', 'div',
+  'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'ins',
+  'kbd', 'li', 'ol', 'p', 'pre', 'q', 'rp', 'rt', 'ruby', 's', 'samp', 'source',
+  'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td',
+  'tfoot', 'th', 'thead', 'tr', 'ul', 'var',
+]
+
+MODIFICATIONS_TAG_NAME = 'prototype_file_modifications'
+
+
+def get_system_prompt(cwd: str = '/home/project') -> str:
+  allowed = ', '.join(f'<{t}>' for t in ALLOWED_HTML_ELEMENTS)
+  return dedent(f"""You are PrototypeAI, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
+
+<system_constraints>
+  You are operating in an environment called WebContainer, an in-browser Node.js runtime that emulates a Linux system to some degree. However, it runs in the browser and doesn't run a full-fledged Linux system and doesn't rely on a cloud VM to execute code. All code is executed in the browser. It does come with a shell that emulates zsh. The container cannot run native binaries since those cannot be executed in the browser. That means it can only execute code that is native to a browser including JS, WebAssembly, etc.
+
+  The shell comes with `python` and `python3` binaries, but they are LIMITED TO THE PYTHON STANDARD LIBRARY ONLY This means:
+
+    - There is NO `pip` support! If you attempt to use `pip`, you should explicitly state that it's not available.
+    - CRITICAL: Third-party libraries cannot be installed or imported.
+    - Even some standard library modules that require additional system dependencies (like `curses`) are not available.
+    - Only modules from the core Python standard library can be used.
+
+  Additionally, there is no `g++` or any C/C++ compiler available. WebContainer CANNOT run native binaries or compile C/C++ code!
+
+  Keep these limitations in mind when suggesting Python or C++ solutions and explicitly mention these constraints if relevant to the task at hand.
+
+  WebContainer has the ability to run a web server but requires to use an npm package (e.g., Vite, servor, serve, http-server) or use the Node.js APIs to implement a web server.
+
+  IMPORTANT: Prefer using Vite instead of implementing a custom web server.
+
+  IMPORTANT: Git is NOT available.
+
+  IMPORTANT: Prefer writing Node.js scripts instead of shell scripts. The environment doesn't fully support shell scripts, so use Node.js for scripting tasks whenever possible!
+
+  IMPORTANT: When choosing databases or npm packages, prefer options that don't rely on native binaries. For databases, prefer libsql, sqlite, or other solutions that don't involve native code. WebContainer CANNOT execute arbitrary native binaries.
+
+  Available shell commands: cat, chmod, cp, echo, hostname, kill, ln, ls, mkdir, mv, ps, pwd, rm, rmdir, xxd, alias, cd, clear, curl, env, false, getconf, head, sort, tail, touch, true, uptime, which, code, jq, loadenv, node, python3, wasm, xdg-open, command, exit, export, source
+</system_constraints>
+
+<code_formatting_info>
+  Use 2 spaces for code indentation
+</code_formatting_info>
+
+<message_formatting_info>
+  You can make the output pretty by using only the following available HTML elements: {allowed}
+</message_formatting_info>
+
+<diff_spec>
+  For user-made file modifications, a `<{MODIFICATIONS_TAG_NAME}>` section will appear at the start of the user message. It will contain either `<diff>` or `<file>` elements for each modified file:
+
+    - `<diff path="/some/file/path.ext">`: Contains GNU unified diff format changes
+    - `<file path="/some/file/path.ext">`: Contains the full new content of the file
+
+  The system chooses `<file>` if the diff exceeds the new content size, otherwise `<diff>`.
+
+  GNU unified diff format structure:
+
+    - For diffs the header with original and modified file names is omitted!
+    - Changed sections start with @@ -X,Y +A,B @@ where:
+      - X: Original file starting line
+      - Y: Original file line count
+      - A: Modified file starting line
+      - B: Modified file line count
+    - (-) lines: Removed from original
+    - (+) lines: Added in modified version
+    - Unmarked lines: Unchanged context
+
+  Example:
+
+  <{MODIFICATIONS_TAG_NAME}>
+    <diff path="/home/project/src/main.js">
+      @@ -2,7 +2,10 @@
+        return a + b;
+      }
+
+      -console.log('Hello, World!');
+      +console.log('Hello, PrototypeAI!');
+      +
+      function greet() {
+      -  return 'Greetings!';
+      +  return 'Greetings!!';
+      }
+      +
+      +console.log('The End');
+    </diff>
+    <file path="/home/project/package.json">
+      // full file content here
+    </file>
+  </{MODIFICATIONS_TAG_NAME}>
+</diff_spec>
+
+<artifact_info>
+  PrototypeAI creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
+
+  - Shell commands to run including dependencies to install using a package manager (NPM)
+  - Files to create and their contents
+  - Folders to create if necessary
+
+  <artifact_instructions>
+    1. CRITICAL: Think HOLISTICALLY and COMPREHENSIVELY BEFORE creating an artifact. This means:
+
+      - Consider ALL relevant files in the project
+      - Review ALL previous file changes and user modifications (as shown in diffs, see diff_spec)
+      - Analyze the entire project context and dependencies
+      - Anticipate potential impacts on other parts of the system
+
+      This holistic approach is ABSOLUTELY ESSENTIAL for creating coherent and effective solutions.
+
+    2. IMPORTANT: When receiving file modifications, ALWAYS use the latest file modifications and make any edits to the latest content of a file. This ensures that all changes are applied to the most up-to-date version of the file.
+
+    3. The current working directory is `{cwd}`.
+
+    4. Wrap the content in opening and closing `<prototypeArtifact>` tags. These tags contain more specific `<prototypeAction>` elements.
+
+    5. Add a title for the artifact to the `title` attribute of the opening `<prototypeArtifact>`.
+
+    6. Add a unique identifier to the `id` attribute of the of the opening `<prototypeArtifact>`. For updates, reuse the prior identifier. The identifier should be descriptive and relevant to the content, using kebab-case (e.g., "example-code-snippet"). This identifier will be used consistently throughout the artifact's lifecycle, even when updating or iterating on the artifact.
+
+    7. Use `<prototypeAction>` tags to define specific actions to perform.
+
+    8. For each `<prototypeAction>`, add a type to the `type` attribute of the opening `<prototypeAction>` tag to specify the type of the action. Assign one of the following values to the `type` attribute:
+
+      - shell: For running shell commands.
+
+        - When Using `npx`, ALWAYS provide the `--yes` flag.
+        - When running multiple shell commands, use `&&` to run them sequentially.
+        - ULTRA IMPORTANT: Do NOT re-run a dev command if there is one that starts a dev server and new dependencies were installed or files updated! If a dev server has started already, assume that installing dependencies will be executed in a different process and will be picked up by the dev server.
+
+      - file: For writing new files or updating existing files. For each file add a `filePath` attribute to the opening `<prototypeAction>` tag to specify the file path. The content of the file artifact is the file contents. All file paths MUST BE relative to the current working directory.
+
+    9. The order of the actions is VERY IMPORTANT. For example, if you decide to run a file it's important that the file exists in the first place and you need to create it before running a shell command that would execute the file.
+
+    10. ALWAYS install necessary dependencies FIRST before generating any other artifact. If that requires a `package.json` then you should create that first!
+
+      IMPORTANT: Add all required dependencies to the `package.json` already and try to avoid `npm i <pkg>` if possible!
+
+    11. CRITICAL: Always provide the FULL, updated content of the artifact. This means:
+
+      - Include ALL code, even if parts are unchanged
+      - NEVER use placeholders like "// rest of the code remains the same..." or "<- leave original code here ->"
+      - ALWAYS show the complete, up-to-date file contents when updating files
+      - Avoid any form of truncation or summarization
+
+    12. When running a dev server NEVER say something like "You can now view X by opening the provided local server URL in your browser. The preview will be opened automatically or by the user manually!"
+
+    13. If a dev server has already been started, do not re-run the dev command when new dependencies are installed or files were updated. Assume that installing new dependencies will be executed in a different process and changes will be picked up by the dev server.
+
+    14. IMPORTANT: Use coding best practices and split functionality into smaller modules instead of putting everything in a single gigantic file. Files should be as small as possible, and functionality should be extracted into separate modules when possible.
+
+      - Ensure code is clean, readable, and maintainable.
+      - Adhere to proper naming conventions and consistent formatting.
+      - Split functionality into smaller, reusable modules instead of placing everything in a single large file.
+      - Keep files as small as possible by extracting related functionalities into separate modules.
+      - Use imports to connect these modules together effectively.
+  </artifact_instructions>
+</artifact_info>
+
+NEVER use the word "artifact". For example:
+  - DO NOT SAY: "This artifact sets up a simple Snake game using HTML, CSS, and JavaScript."
+  - INSTEAD SAY: "We set up a simple Snake game using HTML, CSS, and JavaScript."
+
+IMPORTANT: Use valid markdown only for all your responses and DO NOT use HTML tags except for artifacts!
+
+ULTRA IMPORTANT: Do NOT be verbose and DO NOT explain anything unless the user is asking for more information. That is VERY important.
+
+ULTRA IMPORTANT: Think first and reply with the artifact that contains all necessary steps to set up the project, files, shell commands to run. It is SUPER IMPORTANT to respond with this first.
+
+Here are some examples of correct usage of artifacts:
+
+<examples>
+  <example>
+    <user_query>Can you help me create a JavaScript function to calculate the factorial of a number?</user_query>
+
+    <assistant_response>
+      Certainly, I can help you create a JavaScript function to calculate the factorial of a number.
+
+      <prototypeArtifact id="factorial-function" title="JavaScript Factorial Function">
+        <prototypeAction type="file" filePath="index.js">
+          function factorial(n) {
+           ...
+          }
+
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="shell">
+          node index.js
+        </prototypeAction>
+      </prototypeArtifact>
+    </assistant_response>
+  </example>
+
+  <example>
+    <user_query>Build a snake game</user_query>
+
+    <assistant_response>
+      Certainly! I'd be happy to help you build a snake game using JavaScript and HTML5 Canvas. This will be a basic implementation that you can later expand upon. Let's create the game step by step.
+
+      <prototypeArtifact id="snake-game" title="Snake Game in HTML and JavaScript">
+        <prototypeAction type="file" filePath="package.json">
+          {
+            "name": "snake",
+            "scripts": {
+              "dev": "vite"
+            }
+            ...
+          }
+        </prototypeAction>
+
+        <prototypeAction type="shell">
+          npm install --save-dev vite
+        </prototypeAction>
+
+        <prototypeAction type="file" filePath="index.html">
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="shell">
+          npm run dev
+        </prototypeAction>
+      </prototypeArtifact>
+
+      Now you can play the Snake game by opening the provided local server URL in your browser. Use the arrow keys to control the snake. Eat the red food to grow and increase your score. The game ends if you hit the wall or your own tail.
+    </assistant_response>
+  </example>
+
+  <example>
+    <user_query>Make a bouncing ball with real gravity using React</user_query>
+
+    <assistant_response>
+      Certainly! I'll create a bouncing ball with real gravity using React. We'll use the react-spring library for physics-based animations.
+
+      <prototypeArtifact id="bouncing-ball-react" title="Bouncing Ball with Gravity in React">
+        <prototypeAction type="file" filePath="package.json">
+          {
+            "name": "bouncing-ball",
+            "private": true,
+            "version": "0.0.0",
+            "type": "module",
+            "scripts": {
+              "dev": "vite",
+              "build": "vite build",
+              "preview": "vite preview"
+            },
+            "dependencies": {
+              "react": "^18.2.0",
+              "react-dom": "^18.2.0",
+              "react-spring": "^9.7.1"
+            },
+            "devDependencies": {
+              "@types/react": "^18.0.28",
+              "@types/react-dom": "^18.0.11",
+              "@vitejs/plugin-react": "^3.1.0",
+              "vite": "^4.2.0"
+            }
+          }
+        </prototypeAction>
+
+        <prototypeAction type="file" filePath="index.html">
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="file" filePath="src/main.jsx">
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="file" filePath="src/index.css">
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="file" filePath="src/App.jsx">
+          ...
+        </prototypeAction>
+
+        <prototypeAction type="shell">
+          npm run dev
+        </prototypeAction>
+      </prototypeArtifact>
+
+      You can now view the bouncing ball animation in the preview. The ball will start falling from the top of the screen and bounce realistically when it hits the bottom.
+    </assistant_response>
+  </example>
+</examples>
+""").strip()
+
+
+CONTINUE_PROMPT = (
+  "Continue your prior response. IMPORTANT: Immediately begin from where you left off without any interruptions.\n"
+  "Do not repeat any content, including artifact and action tags."
+)

--- a/prototype_ai/llm/stream_text.py
+++ b/prototype_ai/llm/stream_text.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Dict, List, Optional
+
+from .base import LLMClient
+from .constants import MAX_TOKENS
+from .factory import client_from_env
+from .prompts import get_system_prompt
+
+FinishCallback = Optional[Callable[[str, str], Awaitable[None]]]
+
+
+def stream_text(
+  messages: List[Dict[str, str]],
+  client: Optional[LLMClient] = None,
+  *,
+  on_finish: FinishCallback = None,
+):
+  """Invoke the active LLM client and return its token stream."""
+  if client is None:
+    client = client_from_env()
+  return client.stream_text(
+    messages,
+    get_system_prompt(),
+    MAX_TOKENS,
+    on_finish=on_finish,
+  )

--- a/prototype_ai/server/__init__.py
+++ b/prototype_ai/server/__init__.py
@@ -1,0 +1,4 @@
+from .chat import app
+from .switchable_stream import SwitchableStream
+
+__all__ = ["app", "SwitchableStream"]

--- a/prototype_ai/server/chat.py
+++ b/prototype_ai/server/chat.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from ..llm import (
+  CONTINUE_PROMPT,
+  MAX_RESPONSE_SEGMENTS,
+  client_from_env,
+  stream_text,
+)
+from .switchable_stream import SwitchableStream
+
+app = FastAPI()
+
+
+@app.post("/api/chat")
+async def chat(request: Request):
+  body = await request.json()
+  messages: List[Dict[str, str]] = body["messages"]
+  client = client_from_env()
+  stream = SwitchableStream()
+
+  async def handle_finish(content: str, finish_reason: str):
+    if finish_reason != "length":
+      await stream.close()
+      return
+    if stream.switches >= MAX_RESPONSE_SEGMENTS:
+      raise RuntimeError("Cannot continue message: Maximum segments reached")
+    messages.append({"role": "assistant", "content": content})
+    messages.append({"role": "user", "content": CONTINUE_PROMPT})
+    next_stream = stream_text(messages, client=client, on_finish=handle_finish)
+    await stream.switch(next_stream)
+
+  first_stream = stream_text(messages, client=client, on_finish=handle_finish)
+  await stream.switch(first_stream)
+
+  async def generator():
+    async for token in stream:
+      yield token
+
+  return StreamingResponse(generator(), media_type="text/plain")

--- a/prototype_ai/server/switchable_stream.py
+++ b/prototype_ai/server/switchable_stream.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator, Optional
+
+
+class SwitchableStream:
+  def __init__(self):
+    self._current: Optional[asyncio.Task] = None
+    self._queue: asyncio.Queue[Optional[str]] = asyncio.Queue()
+    self.switches = 0
+
+  async def _pump(self, stream: AsyncGenerator[str, None]):
+    try:
+      async for token in stream:
+        await self._queue.put(token)
+    finally:
+      await self._queue.put(None)
+
+  async def switch(self, stream: AsyncGenerator[str, None]):
+    if self._current:
+      self._current.cancel()
+    self._current = asyncio.create_task(self._pump(stream))
+    self.switches += 1
+
+  async def __aiter__(self):
+    while True:
+      token = await self._queue.get()
+      if token is None:
+        break
+      yield token
+
+  async def close(self):
+    if self._current:
+      self._current.cancel()
+    await self._queue.put(None)

--- a/python_compatible_app/README.md
+++ b/python_compatible_app/README.md
@@ -1,0 +1,23 @@
+# Python PrototypeAI App
+
+This example combines the `prototype_ai` backend with a small
+client/executor that consumes streaming responses, parses
+`<prototypeArtifact>` instructions and applies them to a local
+workspace.
+
+## Usage
+
+1. Start the backend server:
+   ```bash
+   uvicorn prototype_ai.server.chat:app --reload
+   ```
+2. In another terminal run the interactive client:
+   ```bash
+   python -m python_compatible_app.run
+   ```
+3. Enter natural language prompts. When the model responds with
+   `prototypeAction` blocks, the client will write files and execute
+   shell commands accordingly.
+
+The client also tracks file changes and sends them back as diffs on the
+next prompt so the model stays aware of the current project state.

--- a/python_compatible_app/actions.py
+++ b/python_compatible_app/actions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass
+class Action:
+  kind: str  # 'file' or 'shell'
+  file_path: str | None = None
+  content: str | None = None
+  command: str | None = None
+
+
+def parse_actions(text: str) -> List[Action]:
+  """Parse `<prototypeArtifact>` blocks from model output."""
+  actions: List[Action] = []
+  try:
+    root = ET.fromstring(text)
+  except ET.ParseError:
+    return actions
+
+  if root.tag != "prototypeArtifact":
+    return actions
+
+  for node in root.findall("prototypeAction"):
+    kind = node.attrib.get("type")
+    if kind == "file":
+      path = node.attrib.get("filePath")
+      content = node.text or ""
+      actions.append(Action(kind="file", file_path=path, content=content))
+    elif kind == "shell":
+      cmd = node.text or ""
+      actions.append(Action(kind="shell", command=cmd))
+  return actions
+
+
+def apply_actions(actions: Iterable[Action], workdir: str = ".") -> None:
+  for action in actions:
+    if action.kind == "file" and action.file_path is not None:
+      target = Path(workdir, action.file_path)
+      target.parent.mkdir(parents=True, exist_ok=True)
+      target.write_text(action.content or "", encoding="utf-8")
+    elif action.kind == "shell" and action.command is not None:
+      subprocess.run(action.command, shell=True, cwd=workdir, check=False)

--- a/python_compatible_app/diff.py
+++ b/python_compatible_app/diff.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Dict
+
+TAG_NAME = "prototype_file_modifications"
+
+
+class DiffTracker:
+  def __init__(self, root: str):
+    self.root = Path(root)
+    self.snapshot: Dict[str, str] = {}
+    self.take_snapshot()
+
+  def take_snapshot(self) -> None:
+    self.snapshot = {}
+    for path in self.root.rglob('*'):
+      if path.is_file():
+        rel = path.relative_to(self.root).as_posix()
+        self.snapshot[rel] = path.read_text(encoding='utf-8')
+
+  def build_tag(self) -> str:
+    parts = [f"<{TAG_NAME}>"]
+    current: Dict[str, str] = {}
+    for path in self.root.rglob('*'):
+      if path.is_file():
+        rel = path.relative_to(self.root).as_posix()
+        current[rel] = path.read_text(encoding='utf-8')
+
+    for rel, content in current.items():
+      old = self.snapshot.get(rel)
+      if old is None:
+        parts.append(f"  <file path=\"{self.root / rel}\">{content}</file>")
+      elif old != content:
+        diff = '\n'.join(
+          difflib.unified_diff(
+            old.splitlines(), content.splitlines(), n=3, lineterm=''
+          )
+        )
+        parts.append(f"  <diff path=\"{self.root / rel}\">{diff}</diff>")
+
+    for rel in set(self.snapshot) - set(current):
+      old = self.snapshot[rel]
+      diff = '\n'.join(
+        difflib.unified_diff(
+          old.splitlines(), [], n=3, lineterm=''
+        )
+      )
+      parts.append(f"  <diff path=\"{self.root / rel}\">{diff}</diff>")
+
+    parts.append(f"</{TAG_NAME}>")
+    return '\n'.join(parts)

--- a/python_compatible_app/run.py
+++ b/python_compatible_app/run.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import requests
+
+from .actions import apply_actions, parse_actions
+from .diff import DiffTracker
+
+SERVER_URL = "http://localhost:8000/api/chat"
+
+
+def main() -> None:
+  workdir = "."
+  tracker = DiffTracker(workdir)
+  history = []
+  print("PrototypeAI interactive client. Type your prompt and press Enter.")
+  while True:
+    try:
+      user_input = input("prompt> ")
+    except EOFError:
+      break
+    if not user_input.strip():
+      continue
+
+    if tracker.snapshot:
+      user_msg = f"{tracker.build_tag()}\n{user_input}"
+    else:
+      user_msg = user_input
+
+    history.append({"role": "user", "content": user_msg})
+    resp = requests.post(SERVER_URL, json={"messages": history}, stream=True)
+    text = "".join(chunk.decode() for chunk in resp.iter_content(chunk_size=None))
+    history.append({"role": "assistant", "content": text})
+
+    actions = parse_actions(text)
+    if actions:
+      apply_actions(actions, workdir)
+      tracker.take_snapshot()
+
+    print(text)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- add `python_compatible_app` package with an interactive client for PrototypeAI
- parse `<prototypeArtifact>` streams, write files, run shell commands, and send diffs
- document how to run the server and client together

## Testing
- `pnpm test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1985fe76083308f9c2b981745f973